### PR TITLE
Fix clean air switch errors & simplify its logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,22 +170,14 @@ FrigidaireAirConditionerAccessory.prototype = {
 
   getCleanAir: function (callback) {
     var self = this;
-
     this.AC.getCleanAir(self.applianceSn, function (err, result) {
-      var newValue;
-      if (err) return console.error(err);
-      if (result == self.AC.CLEANAIR_ON) newValue = true;
-      else if (result == self.AC.CLEANAIR_OFF) newValue = false;
+      if (err) return callback(err);
+      if (result == self.AC.CLEANAIR_ON) self.cleanAir = true;
+      else if (result == self.AC.CLEANAIR_OFF) self.cleanAir = false;
 
       self.log("getCleanAir: ", self.cleanAir);
 
-      if (self.cleanAir != newValue) {
-        self.cleanAir = newValue;
-        self.cleanAirSwitch
-          .setCharacteristic(Characteristic.On, newValue);
-      }
-
-      return callback(null, self.cleanAir);
+      callback(null, self.cleanAir);
     });
   },
 
@@ -194,19 +186,12 @@ FrigidaireAirConditionerAccessory.prototype = {
     if (value == true) var newMode = self.AC.CLEANAIR_ON;
     else if (value == false) var newMode = self.AC.CLEANAIR_OFF;
 
-    if (self.cleanAir == value)
-      return callback(null, self.cleanAir);
-
-    this.AC.cleanAir(self.applianceSn, newMode, function (err, result) {
-      if (err) return console.error(err);
-
-      self.log("getCleanAir: ", newMode);
+    if (self.cleanAir == value) return callback(null, null)
+    this.AC.cleanAir(self.applianceSn, newMode, function (err) {
+      if (err) return callback(err);
       self.cleanAir = value;
-
-      self.cleanAirSwitch
-        .setCharacteristic(Characteristic.On, value);
-
-      return callback(null, self.cleanAir);
+      self.log("getCleanAir: ", self.cleanAir);
+      callback(null, null)
     });
   },
 


### PR DESCRIPTION
Hey, thanks for creating this plugin - it is great being able to operate my AC inside of the Home app.

This PR fixes a warning and stacktrace caused by a combination of cyclical logic and incorrect function return values involving the getCleanAir and setCleanAir functions. Sample warning and stacktrace below:
```
[6/8/2022, 3:47:54 PM] [homebridge-frigidaire] Characteristic 'On': SET handler returned write response value, though the characteristic doesn't support write response. See https://homebridge.io/w/JtMGR for more info.

[6/8/2022, 3:47:54 PM] [homebridge-frigidaire] Error: 
    at On.Characteristic.characteristicWarning (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:2142:105)
    at /usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:1756:22
    at /usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/util/once.ts:10:18
    at /homebridge/node_modules/homebridge-frigidaire/index.js:201:7
    at Request.postResponseCallback [as _callback] (/homebridge/node_modules/homebridge-frigidaire/node_modules/frigidaire/lib/frigidaire.js:418:25)
    at Request.self.callback (/homebridge/node_modules/homebridge-frigidaire/node_modules/request/request.js:185:22)
    at Request.emit (node:events:527:28)
    at Request.<anonymous> (/homebridge/node_modules/homebridge-frigidaire/node_modules/request/request.js:1154:10)
    at Request.emit (node:events:527:28)
    at IncomingMessage.<anonymous> (/homebridge/node_modules/homebridge-frigidaire/node_modules/request/request.js:1076:12)
    at Object.onceWrapper (node:events:641:28)
    at IncomingMessage.emit (node:events:539:35)
    at endReadableNT (node:internal/streams/readable:1345:12)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
```

These changes fix the stacktraces and enable expected behavior for the clean air switch (my AC model supports this switch). In conjunction with #41, I believe this fixes all known issues I've seen with this plugin. I'd also like to note that while the set command updating the clean air switch works well, the get command shortly after a set temporarily sets the switch back to its previous state for a few seconds. This is likely because the AC itself isn't returning the updated state when a get request is made. Without introducing a caching layer, I think this is actually expected behavior.